### PR TITLE
Use an unsigned long for the baudrate and use Arduino core methods

### DIFF
--- a/src/ModbusSlave.h
+++ b/src/ModbusSlave.h
@@ -50,7 +50,7 @@ typedef void(*CallBackFunc)(uint8_t, uint16_t, uint16_t);
 class Modbus {
 public:
     Modbus(uint8_t unitID, int ctrlPin);
-    void begin(int boud);
+    void begin(unsigned long boud);
     int poll();
     uint16_t readRegisterFromBuffer(int offset);
     void writeCoilToBuffer(int offset, uint16_t state);


### PR DESCRIPTION
I found the bug that prevents us to use baudrates higher than 19200 (37767 actually). A `int` was used instead of a `unsigned long` in the `begin()` method :)

And I have add some *improvements* mentioned in the [issue](https://github.com/yaacov/ArduinoModbusSlave/issues/1) #1. 

For the value of the timeout, I have used the one found in [that library](https://github.com/andresarmento/modbus-arduino/blob/master/libraries/ModbusSerial/ModbusSerial.cpp#L37).  
Note that I now use `micros()` instead of `millis()` to have a more precise timing. But `micros()` will rollover after only 70 minutes. To avoid that, we can still use `millis()` that will rollover after approximately 50 days, or a more robust approach would be to use a custom `superMicros()` using a 64 bits variable like illustrated [here](https://www.carnetdumaker.net/articles/la-gestion-du-temps-avec-arduino/#bonus-gerer-le-debordement-de-millis-et-micros) (sorry, it is in French).

I have removed the `Serial.flush()`. If they were needed to clear the RX buffer, we should use the following instead:
```C
while(Serial.read() >= 0);
```

I have replaced the custom `serialRead()` method by the Arduino's `Serial.readBytes()` with a timeout of `0`.

Finally, I have replaced the polling of the `UCSR0A` register by the use of the Arduino's `Serial.flush()` method, so the library should work with other Arduino architectures like the Arduino DUE and Zero (the build is OK for the Due, I will try to upload it to the DUE tonight).

I manage to have a working communication at 115200 bauds while using [qmodbus](https://github.com/ed-chemnitz/qmodbus/) on a PC and an Arduino UNO.