### PR TITLE
Serial port indepedent

### DIFF
--- a/examples/full/full.ino
+++ b/examples/full/full.ino
@@ -75,8 +75,9 @@ void setup() {
     slave.cbVector[CB_READ_REGISTERS] = readMemory;
     slave.cbVector[CB_WRITE_MULTIPLE_REGISTERS] = writeMemory;
     
-    // start slave at baud 9600 on Serial.
-    slave.begin( BAUDRATE ); // baud = 9600
+    // set Serial and slave at baud 9600.
+    Serial.begin( BAUDRATE );
+    slave.begin( BAUDRATE );
 }
 
 void loop() {

--- a/examples/simple/simple.ino
+++ b/examples/simple/simple.ino
@@ -52,7 +52,8 @@ void setup() {
     slave.cbVector[CB_READ_COILS] = readDigitalIn;
     slave.cbVector[CB_READ_REGISTERS] = readAnalogIn;
 
-    // start slave at baud 9600 on Serial
+    // set Serial and slave at baud 9600.
+    Serial.begin( BAUDRATE );
     slave.begin( BAUDRATE );
 }
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -5,7 +5,8 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-Modbus	KEYWORD1
+ModbusSlave					KEYWORD1
+Modbus						KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)

--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=A Modbus Slave library for Arduino.
 paragraph=This modbus slave library uses callbacks to handle modbus requests.
 category=Communication
 url=https://github.com/yaacov/ArduinoModbusSlave
-architectures=avr
+architectures=avr,sam,samd

--- a/src/ModbusSlave.h
+++ b/src/ModbusSlave.h
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF  THIS SOFTWARE.
  */
 
-#include <inttypes.h>
+#include <Arduino.h>
 
 #define MAX_BUFFER 64
 
@@ -50,6 +50,7 @@ typedef void(*CallBackFunc)(uint8_t, uint16_t, uint16_t);
 class Modbus {
 public:
     Modbus(uint8_t unitID, int ctrlPin);
+    Modbus(Stream &serial, uint8_t unitID, int ctrlPin);
     void begin(unsigned long boud);
     int poll();
     uint16_t readRegisterFromBuffer(int offset);
@@ -59,6 +60,7 @@ public:
 
     CallBackFunc cbVector[4];
 private:
+    Stream &serial;
     uint32_t timeout;
     uint32_t last_receive_time;
     uint16_t last_receive_len;


### PR DESCRIPTION
- Used a reference to a Stream object. This allows to use Arduino Zero's
  SerialUSB or SoftwareSerial classes.
- But the Stream class does not use the baudrate so we have to specify
  it manually with `Serial.begin()`.
- The legacy constructor stays available and uses `Serial` by default.
- Added the `ModbuSlave` keyword to get color on the include statement.
- Added the `sam` and `samd` architectures, tested on Arduino **Due** and
  Arduino **Zero**.