### PR TITLE
Message too long with SoftwareSerial on Arduino nano

### DIFF
--- a/src/ModbusSlave.cpp
+++ b/src/ModbusSlave.cpp
@@ -147,6 +147,10 @@ int Modbus::poll() {
     // check minimum length.
     if (lengthIn < 8) return 0;
 
+    // this removes the null character that sometimes
+    // is get from the SoftwareSerial on the "nano"
+    if(lengthIn > 8 && bufIn[lengthIn-1] == 0) lengthIn--;
+
     // check unit-id
     if (bufIn[0] != unitID) return 0;
 


### PR DESCRIPTION
When using SoftwareSerial on the Arduino nano (v3), I could see an extra null character after the CRC.
I verified this situation by just using the SofwareSerial alone and echoing the character hex value on the hardware serial.
The total message in this case is 9 character which is considered invalid from the library.
The pull request contains an additional control that decrease the length by one when the message length is larger then expected.
I preferred to calculate the last character position instead hardcoding the "8" in case of future changes on the incoming message length.

FYI I did not try using the hardware Serial but I suspect it would be there anyway because I believe it is a timing problem and not a serial library issue.