### PR TITLE
Remove extra null, only if length is one byte longer then message.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@
 *.exe
 *.out
 *.app
+.pioenvs
+.piolibdeps
+.clang_complete
+.gcc-flags.json

--- a/src/ModbusSlave.cpp
+++ b/src/ModbusSlave.cpp
@@ -166,7 +166,7 @@ int Modbus::poll() {
      */
     switch (fc) {
         case FC_READ_COILS: // read coils (digital out state)
-        case FC_READ_DISCRETE_INPUT:
+        case FC_READ_DISCRETE_INPUT: // read input state (digital in)
         case FC_READ_HOLDING_REGISTERS: // read holding registers (analog out state)
         case FC_READ_INPUT_REGISTERS: // read input registers (analog in)
             // sanity check.

--- a/src/ModbusSlave.cpp
+++ b/src/ModbusSlave.cpp
@@ -159,42 +159,42 @@ int Modbus::poll() {
      * Get message address and length/status.
      */
     address = word(bufIn[2], bufIn[3]); // first register.
-    length = word(bufIn[4], bufIn[5]);  // number of registers to act apone.
+    length = word(bufIn[4], bufIn[5]);  // number of registers to act upone or status.
 
     /**
-     * this removes any trailing noise after message
+     * Output length sanity check, and remove trailing noise from message.
      */
     switch (fc) {
-      case FC_READ_COILS: // read coils (digital out state)
-      case FC_READ_DISCRETE_INPUT:
-      case FC_READ_HOLDING_REGISTERS: // read holding registers (analog out state)
-      case FC_READ_INPUT_REGISTERS: // read input registers (analog in)
-          // sanity check.
-          if (length > MAX_BUFFER) return 0;
+        case FC_READ_COILS: // read coils (digital out state)
+        case FC_READ_DISCRETE_INPUT:
+        case FC_READ_HOLDING_REGISTERS: // read holding registers (analog out state)
+        case FC_READ_INPUT_REGISTERS: // read input registers (analog in)
+            // sanity check.
+            if (length > MAX_BUFFER) return 0;
 
-          // ignore tailing nulls.
-          lengthIn = 8;
+            // ignore tailing nulls.
+            lengthIn = 8;
 
-          break;
-      case FC_WRITE_COIL:
-          status = length; // 0xff00 - on, 0x0000 - off
+            break;
+        case FC_WRITE_COIL:
+            status = length; // 0xff00 - on, 0x0000 - off
 
-          // ignore tailing nulls.
-          lengthIn = 8;
+            // ignore tailing nulls.
+            lengthIn = 8;
 
-          break;
-      case FC_WRITE_MULTIPLE_REGISTERS:
-          // sanity check.
-          if (length > MAX_BUFFER) return 0;
+            break;
+        case FC_WRITE_MULTIPLE_REGISTERS:
+            // sanity check.
+            if (length > MAX_BUFFER) return 0;
 
-          // ignore tailing nulls.
-          lengthIn = (int)(7 + length * 2 + 2);
+            // ignore tailing nulls.
+            lengthIn = (int)(7 + length * 2 + 2);
 
-          break;
-      default:
-          // unknown command
-          return 0;
-          break;
+            break;
+        default:
+            // unknown command
+            return 0;
+            break;
     }
 
     // check crc.

--- a/src/ModbusSlave.cpp
+++ b/src/ModbusSlave.cpp
@@ -147,9 +147,17 @@ int Modbus::poll() {
     // check minimum length.
     if (lengthIn < 8) return 0;
 
-    // this removes the null character that sometimes
-    // is get from the SoftwareSerial on the "nano"
-    if(lengthIn > 8 && bufIn[lengthIn-1] == 0) lengthIn--;
+    /**
+     * this removes the null character that sometimes
+     * is get from the SoftwareSerial on the "nano"
+     * posible message length are:
+     *   FC1..6 : length = 8  (with extra null 9)
+     *   FC15   : length = 11 (with extra null 12)
+     *   FC16   : length = 13 (with extra null 14)
+     */
+    if((lengthIn == 9 || lengthIn == 12 || lengthIn == 14) && bufIn[lengthIn-1] == 0) {
+      lengthIn--;
+    }
 
     // check unit-id
     if (bufIn[0] != unitID) return 0;
@@ -233,7 +241,7 @@ int Modbus::poll() {
             if (length > MAX_BUFFER) return 0;
 
             // check command length
-            if (lengthIn != (7 + length * 2 + 2)) return 0;
+            if ((uint16_t)lengthIn != (7 + length * 2 + 2)) return 0;
 
             // build valid empty answer.
             lengthOut = 8;

--- a/src/ModbusSlave.cpp
+++ b/src/ModbusSlave.cpp
@@ -187,6 +187,9 @@ int Modbus::poll() {
             // sanity check.
             if (length > MAX_BUFFER) return 0;
 
+            // check buffer in size.
+            if (lengthIn < (int)(7 + length * 2 + 2)) return 0;
+
             // ignore tailing nulls.
             lengthIn = (int)(7 + length * 2 + 2);
 


### PR DESCRIPTION
Remove extra null, only if length is one byte longer then message.

In https://github.com/yaacov/ArduinoModbusSlave/pull/6 we remove the extra null when length is bigger then 8, this is a problem for valid messages of length 11 and 13.

In this pull request we look for specific length that can have an extra null.

@raffaeler please take a look