### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,40 +5,40 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-ModbusSlave					KEYWORD1
-Modbus						KEYWORD1
+ModbusSlave	KEYWORD1
+Modbus	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-begin						KEYWORD2
-poll						KEYWORD2
-readCoilFromBuffer			KEYWORD2
-readRegisterFromBuffer		KEYWORD2
-writeCoilToBuffer			KEYWORD2
-writeRegisterToBuffer		KEYWORD2
-writeStringToBuffer			KEYWORD2
+begin	KEYWORD2
+poll	KEYWORD2
+readCoilFromBuffer	KEYWORD2
+readRegisterFromBuffer	KEYWORD2
+writeCoilToBuffer	KEYWORD2
+writeRegisterToBuffer	KEYWORD2
+writeStringToBuffer	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
 #######################################
-cbVector				KEYWORD2
+cbVector	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
-MAX_BUFFER					LITERAL1
-FC_READ_COILS				LITERAL1
-FC_READ_DISCRETE_INPUT		LITERAL1
+MAX_BUFFER	LITERAL1
+FC_READ_COILS	LITERAL1
+FC_READ_DISCRETE_INPUT	LITERAL1
 FC_READ_HOLDING_REGISTERS	LITERAL1
-FC_READ_INPUT_REGISTERS		LITERAL1
-FC_WRITE_COIL				LITERAL1
-FC_WRITE_REGISTER			LITERAL1
-FC_WRITE_MULTIPLE_COILS		LITERAL1
+FC_READ_INPUT_REGISTERS	LITERAL1
+FC_WRITE_COIL	LITERAL1
+FC_WRITE_REGISTER	LITERAL1
+FC_WRITE_MULTIPLE_COILS	LITERAL1
 FC_WRITE_MULTIPLE_REGISTERS	LITERAL1
-CB_READ_COILS				LITERAL1
-CB_READ_REGISTERS			LITERAL1
-CB_WRITE_COILS				LITERAL1
-CB_WRITE_REGISTERS		LITERAL1
-COIL_OFF					LITERAL1
-COIL_ON						LITERAL1
+CB_READ_COILS	LITERAL1
+CB_READ_REGISTERS	LITERAL1
+CB_WRITE_COILS	LITERAL1
+CB_WRITE_REGISTERS	LITERAL1
+COIL_OFF	LITERAL1
+COIL_ON	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords