### PR TITLE
Fixed issues with pins which equals 0x00

### DIFF
--- a/src/ModbusSlave.cpp
+++ b/src/ModbusSlave.cpp
@@ -53,7 +53,7 @@ Modbus::Modbus(Stream &_serial, uint8_t _unitID, int _ctrlPin)
  */
 void Modbus::begin(unsigned long boud) {
     // set control pin
-    if (ctrlPin) {
+    if (ctrlPin >= 0) {
         pinMode(ctrlPin, OUTPUT);
     }
 
@@ -364,7 +364,7 @@ int Modbus::poll() {
     /**
      * Transmit
      */
-    if (ctrlPin) {
+    if (ctrlPin >= 0) {
         // set rs485 control pin to write
         digitalWrite(ctrlPin, HIGH);
 

--- a/src/ModbusSlave.h
+++ b/src/ModbusSlave.h
@@ -15,6 +15,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF  THIS SOFTWARE.
  */
 
+#ifndef MODBUSSLAVE_H
+#define MODBUSSLAVE_H
 #include <Arduino.h>
 
 #define MAX_BUFFER 64
@@ -86,9 +88,9 @@ private:
     uint16_t last_receive_len;
     uint16_t calcCRC(uint8_t *buf, int length);
 
-    int ctrlPin;
+    int ctrlPin = -1;
     uint8_t unitID;
     uint8_t bufIn[MAX_BUFFER];
     uint8_t bufOut[MAX_BUFFER];
 };
-
+#endif


### PR DESCRIPTION
If you choosen a pin which is at the first entry of the pindefinition array, then this pin represents 0. 
You have always checked if ctrlpin is greater than 0. Therefore i had the problem that i was not able to communicate. Since you use an int for ctrlpin. We can initialize them with -1 and check for >= 0. 

The other problem was the inclusion of ModbusSlave.h. 
There was a missing #ifdef therefore my compiler clompained about that and told me that there are multiple definitions of the same things. 

I added the #ifdef and the problem is solved. 

Tested with sloeber and stm32duino!