### PR TITLE
Fix invalid `poll()` return values

### DIFF
--- a/src/ModbusSlave.cpp
+++ b/src/ModbusSlave.cpp
@@ -765,7 +765,7 @@ uint16_t Modbus::writeResponse()
      */
 
     // send buffer
-    uint16_t length;
+    uint16_t length = 0;
     if (_serialTransmissionBufferLength > 0) {
         uint16_t length = min(
             _serialStream.availableForWrite(), 


### PR DESCRIPTION
Fixed a problem with not initialized `length` returning invalid values while in nonblocking write mode