### PR TITLE
Allow multiple slaves without breaking the current API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ##### ModbusSlave library for Arduino
 
-This modbus slave library uses callbacks to handle modbus requests.
+This modbus slave library uses callbacks to handle modbus requests for one or multiple slave ids.
 Handler functions are called on modbus request, and the users can implement them in their sketch.
 
 ### ModbusSlave is fun and easy to use
@@ -24,6 +24,7 @@ And thats it, your sketch is modbus enabled. (see the full examples for more det
 - [Install](#install)
 - [Competabilty](#competabilty)
 - [Callback vector](#callback-vector)
+      - [Multiple Slaves](#multiple-slaves)
       - [Slots](#slots)
       - [Handler function](#handler-function)
       - [Function codes](#function-codes)
@@ -58,7 +59,11 @@ To set a different Serial class, explicitly set the Stream in the Modbus class c
 
 ### Callback vector
 
-Users register handler functions into the callback vector.
+Users register handler functions into the callback vector of the slave.
+
+###### Multiple Slaves
+
+This can be done independently for one or multiple slaves with different IDs.
 
 ###### Slots
 
@@ -91,7 +96,6 @@ Return codes:
 *  STATUS_MEMORY_PARITY_ERROR,
 *  STATUS_GATEWAY_PATH_UNAVAILABLE,
 *  STATUS_GATEWAY_TARGET_DEVICE_FAILED_TO_RESPOND
-
 
 ###### Function codes
 

--- a/examples/multi/multi.ino
+++ b/examples/multi/multi.ino
@@ -1,0 +1,96 @@
+/*
+    Modbus multiple slave example.
+
+    Read and write to two different slaves using Modbus serial connection.
+    
+    This sketch show how to use the callback vector for reading and
+    writing to multiple slaves.
+    
+    * Communicate with two slaves holding the addresses 1 and 3.
+	* Set the callback functions of the slaves indipendently.
+
+    Created 19 08 2019
+    By Tobias Schaffner
+
+    https://github.com/yaacov/ArduinoModbusSlave
+*/
+
+#include <ModbusSlave.h>
+
+#define NUMBER_OF_SLAVES  2
+#define ID_SLAVE_1        1
+#define ID_SLAVE_2        3
+
+uint16_t memorySlave1[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+uint16_t memorySlave2[] = { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+
+// Initialize the array of slaves
+ModbusSlave slaves[NUMBER_OF_SLAVES] = { ModbusSlave(ID_SLAVE_1), ModbusSlave(ID_SLAVE_2) };
+
+// Create the Modbus Object with the slave array 
+Modbus modbus(slaves, NUMBER_OF_SLAVES);
+
+void setup() {
+    // register handler functions for the slaves
+    slaves[0].cbVector[CB_READ_HOLDING_REGISTERS] = readMemorySlave1;
+    slaves[0].cbVector[CB_WRITE_HOLDING_REGISTERS] = writeMemorySlave1;
+    slaves[1].cbVector[CB_READ_HOLDING_REGISTERS] = readMemorySlave2;
+    slaves[1].cbVector[CB_WRITE_HOLDING_REGISTERS] = writeMemorySlave2;
+	
+    // start slave at baud 9600 on Serial
+    Serial.begin( 9600 );
+    modbus.begin( 9600 );
+}
+
+void loop() {
+    // listen for modbus commands con serial port
+    modbus.poll();
+}
+
+/**
+ * Handel Read Holding Registers (FC=03)
+ */
+uint8_t readMemorySlave1(uint8_t fc, uint16_t address, uint16_t length) {
+    Serial.println("In read memory Slave 1");
+    // write registers into the answer buffer
+    for (uint8_t i = 0; i < length; ++i) {
+        modbus.writeRegisterToBuffer(i, memorySlave1[address + i]);
+    }
+    return STATUS_OK;
+}
+
+/**
+ * Handle Write Holding Register(s) (FC=06, FC=16)
+ */
+uint8_t writeMemorySlave1(uint8_t fc, uint16_t address, uint16_t length) {
+    Serial.println("In write memory Slave 1");
+    // set digital pin state(s).
+    for (uint8_t i = 0; i < length; ++i) {
+        memorySlave1[address + i] = modbus.readRegisterFromBuffer(i);
+    }
+    return STATUS_OK;
+}
+
+/**
+ * Handel Read Holding Registers (FC=03)
+ */
+uint8_t readMemorySlave2(uint8_t fc, uint16_t address, uint16_t length) {
+    Serial.println("In read memory Slave 2");
+    // write registers into the answer buffer
+    for (uint8_t i = 0; i < length; ++i) {
+        modbus.writeRegisterToBuffer(i, memorySlave2[address + i]);
+    }
+    return STATUS_OK;
+}
+
+/**
+ * Handle Write Holding Register(s) (FC=06, FC=16)
+ */
+uint8_t writeMemorySlave2(uint8_t fc, uint16_t address, uint16_t length) {
+    Serial.println("In write memory Slave 2");
+    // set digital pin state(s).
+    for (uint8_t i = 0; i < length; ++i) {
+        memorySlave2[address + i] = modbus.readRegisterFromBuffer(i);
+    }
+    return STATUS_OK;
+}

--- a/src/ModbusSlave.cpp
+++ b/src/ModbusSlave.cpp
@@ -49,10 +49,42 @@
  */
 
 /**
+ * Initialize a modbus slave object.
+ *
+ * @param unitAddress the modbus slave unit address.
+ */
+ModbusSlave::ModbusSlave(uint8_t unitAddress = MODBUS_DEFAULT_UNIT_ADDRESS)
+{
+    ModbusSlave::setUnitAddress(unitAddress);
+}
+
+/**
+ * Get the modbus slaves unit address.
+ */
+uint8_t ModbusSlave::getUnitAddress()
+{
+    return _unitAddress;
+}
+
+/**
+ * Sets the modbus slaves unit address.
+ *
+ * @param unitAddress the modbus slaves unit address.
+ */
+void ModbusSlave::setUnitAddress(uint8_t unitAddress)
+{
+    if (unitAddress < MODBUS_ADDRESS_MIN || unitAddress > MODBUS_ADDRESS_MAX)
+    {
+        return;
+    }
+    _unitAddress = unitAddress;
+}
+
+/**
  * Initialize the modbus object.
  *
  * @param unitAddress the modbus slave unit address.
- * @param transmissionControlPin the digital out pin to be used for RS485 
+ * @param transmissionControlPin the digital out pin to be used for RS485.
  * transmission control.
  */
 Modbus::Modbus(uint8_t unitAddress, int transmissionControlPin)
@@ -65,32 +97,64 @@ Modbus::Modbus(uint8_t unitAddress, int transmissionControlPin)
  *
  * @param serialStream the serial stream used for the modbus communication.
  * @param unitAddress the modbus slave unit address.
- * @param transmissionControlPin the digital out pin to be used for RS485
+ * @param transmissionControlPin the digital out pin to be used for RS485.
  * transmission control.
  */
 Modbus::Modbus(Stream &serialStream, uint8_t unitAddress, int transmissionControlPin)
     : _serialStream(serialStream)
 {
     // set modbus slave unit id
-    Modbus::setUnitAddress(unitAddress);
+    _slaves[0].setUnitAddress(unitAddress);
+    cbVector = _slaves[0].cbVector;
 
     // set transmission control pin for RS485 communications.
     _transmissionControlPin = transmissionControlPin;
 }
 
 /**
- * Sets the modbus slave unit address.
+ * Initialize the modbus object.
  *
- * @param unitAddress the modbus slave unit address.
+ * @param slaves Pointer to an array of ModbusSlaves.
+ * @param numberOfSlaves The number of ModbusSlaves in the array.
+ * @param transmissionControlPin the digital out pin to be used for RS485.
+ * transmission control.
+ */
+Modbus::Modbus(ModbusSlave* slaves, uint8_t numberOfSlaves, int transmissionControlPin)
+    : Modbus(Serial, slaves, numberOfSlaves, transmissionControlPin)
+{
+}
+
+/**
+ * Initialize the modbus object.
+ *
+ * @param serialStream the serial stream used for the modbus communication.
+ * @param slaves Pointer to an array of ModbusSlaves.
+ * @param numberOfSlaves The number of ModbusSlaves in the array.
+ * @param transmissionControlPin the digital out pin to be used for RS485.
+ * transmission control.
+ */
+Modbus::Modbus(Stream &serialStream, ModbusSlave* slaves, uint8_t numberOfSlaves, int transmissionControlPin)
+    : _serialStream(serialStream)
+{
+    // set modbus slaves
+    _slaves = slaves;
+    _numberOfSlaves = numberOfSlaves;
+    cbVector = _slaves[0].cbVector;
+
+    // set transmission control pin for RS485 communications.
+    _transmissionControlPin = transmissionControlPin;
+}
+
+/**
+ * Sets the modbus slaves unit address.
+ *
+ * @param unitAddress the modbus slaves unit address.
  */
 void Modbus::setUnitAddress(uint8_t unitAddress)
 {
-    if (unitAddress < MODBUS_ADDRESS_MIN || unitAddress > MODBUS_ADDRESS_MAX)
-    {
-        return;
-    }
-    _unitAddress = unitAddress;
+    _slaves[0].setUnitAddress(unitAddress);
 }
+
 
 /**
  * Gets the total number of bytes sent.
@@ -481,9 +545,7 @@ bool Modbus::readRequest()
             lenght = _serialStream.readBytes(_requestBuffer + _requestBufferLength, MODBUS_MAX_BUFFER - _requestBufferLength);
 
             // if this is the first read, check the address to reject irrelevant requests
-            if (_requestBufferLength == 0 &&
-                lenght > MODBUS_ADDRESS_INDEX &&
-                (_requestBuffer[MODBUS_ADDRESS_INDEX] != _unitAddress && _requestBuffer[MODBUS_ADDRESS_INDEX] != MODBUS_BROADCAST_ADDRESS))
+            if (_requestBufferLength == 0 && lenght > MODBUS_ADDRESS_INDEX && !Modbus::relevantAddress(_requestBuffer[MODBUS_ADDRESS_INDEX]))
             {
                 // bad address, stop reading
                 _isRequestBufferReading = false;
@@ -516,6 +578,23 @@ bool Modbus::readRequest()
     }
 
     return !_isRequestBufferReading && (_requestBufferLength >= MODBUS_FRAME_SIZE);
+}
+
+/**
+ * Returns if one of the slaves has serves the given address.
+ *
+ * @param unitAddress The address that was received.
+ */
+bool Modbus::relevantAddress(uint8_t unitAddress)
+{
+    if (unitAddress == MODBUS_BROADCAST_ADDRESS)
+        return true;
+    for (uint8_t i = 0; i < _numberOfSlaves; ++i)
+    {
+        if (_slaves[i].getUnitAddress() == unitAddress)
+            return true;
+    }
+    return false;
 }
 
 /**
@@ -615,7 +694,7 @@ uint8_t Modbus::createResponse()
         _responseBufferLength += 1;
 
         // execute callback and return the status code
-        return Modbus::executeCallback(CB_READ_EXCEPTION_STATUS, 0, 8);
+        return Modbus::executeCallback(_requestBuffer[MODBUS_ADDRESS_INDEX], CB_READ_EXCEPTION_STATUS, 0, 8);
     case FC_READ_COILS:          // read coils (digital out state)
     case FC_READ_DISCRETE_INPUT: // read input state (digital in)
         // read the the first input address and the number of inputs
@@ -628,7 +707,7 @@ uint8_t Modbus::createResponse()
 
         // execute callback and return the status code
         callbackIndex = _requestBuffer[MODBUS_FUNCTION_CODE_INDEX] == FC_READ_COILS ? CB_READ_COILS : CB_READ_DISCRETE_INPUTS;
-        return Modbus::executeCallback(callbackIndex, firstAddress, addressesLength);
+        return Modbus::executeCallback(_requestBuffer[MODBUS_ADDRESS_INDEX], callbackIndex, firstAddress, addressesLength);
     case FC_READ_HOLDING_REGISTERS: // read holding registers (analog out state)
     case FC_READ_INPUT_REGISTERS:   // read input registers (analog in)
         // read the starting address and the number of inputs
@@ -641,7 +720,7 @@ uint8_t Modbus::createResponse()
 
         // execute callback and return the status code
         callbackIndex = _requestBuffer[MODBUS_FUNCTION_CODE_INDEX] == FC_READ_HOLDING_REGISTERS ? CB_READ_HOLDING_REGISTERS : CB_READ_INPUT_REGISTERS;
-        return Modbus::executeCallback(callbackIndex, firstAddress, addressesLength);
+        return Modbus::executeCallback(_requestBuffer[MODBUS_ADDRESS_INDEX], callbackIndex, firstAddress, addressesLength);
     case FC_WRITE_COIL: // write one coil (digital out)
         // read the address
         firstAddress = readUInt16(_requestBuffer, MODBUS_DATA_INDEX);
@@ -652,7 +731,7 @@ uint8_t Modbus::createResponse()
         memcpy(_responseBuffer + MODBUS_DATA_INDEX, _requestBuffer + MODBUS_DATA_INDEX, _responseBufferLength - MODBUS_FRAME_SIZE);
 
         // execute callback and return the status code
-        return Modbus::executeCallback(CB_WRITE_COILS, firstAddress, 1);
+        return Modbus::executeCallback(_requestBuffer[MODBUS_ADDRESS_INDEX], CB_WRITE_COILS, firstAddress, 1);
     case FC_WRITE_REGISTER:
         // read the address
         firstAddress = readUInt16(_requestBuffer, MODBUS_DATA_INDEX);
@@ -663,7 +742,7 @@ uint8_t Modbus::createResponse()
         memcpy(_responseBuffer + MODBUS_DATA_INDEX, _requestBuffer + MODBUS_DATA_INDEX, _responseBufferLength - MODBUS_FRAME_SIZE);
 
         // execute callback and return the status code
-        return Modbus::executeCallback(CB_WRITE_HOLDING_REGISTERS, firstAddress, 1);
+        return Modbus::executeCallback(_requestBuffer[MODBUS_ADDRESS_INDEX], CB_WRITE_HOLDING_REGISTERS, firstAddress, 1);
     case FC_WRITE_MULTIPLE_COILS: // write coils (digital out)
         // read the starting address and the number of outputs
         firstAddress = readUInt16(_requestBuffer, MODBUS_DATA_INDEX);
@@ -675,7 +754,7 @@ uint8_t Modbus::createResponse()
         memcpy(_responseBuffer + MODBUS_DATA_INDEX, _requestBuffer + MODBUS_DATA_INDEX, _responseBufferLength - MODBUS_FRAME_SIZE);
         
         // execute callback and return the status code
-        return Modbus::executeCallback(CB_WRITE_COILS, firstAddress, addressesLength);
+        return Modbus::executeCallback(_requestBuffer[MODBUS_ADDRESS_INDEX], CB_WRITE_COILS, firstAddress, addressesLength);
     case FC_WRITE_MULTIPLE_REGISTERS: // write holding registers (analog out)
         // read the starting address and the number of outputs
         firstAddress = readUInt16(_requestBuffer, MODBUS_DATA_INDEX);
@@ -687,7 +766,7 @@ uint8_t Modbus::createResponse()
         memcpy(_responseBuffer + MODBUS_DATA_INDEX, _requestBuffer + MODBUS_DATA_INDEX, _responseBufferLength - MODBUS_FRAME_SIZE);
 
         // execute callback and return the status code
-        return Modbus::executeCallback(CB_WRITE_HOLDING_REGISTERS, firstAddress, addressesLength);
+        return Modbus::executeCallback(_requestBuffer[MODBUS_ADDRESS_INDEX], CB_WRITE_HOLDING_REGISTERS, firstAddress, addressesLength);
     default:
         return STATUS_ILLEGAL_FUNCTION;
     }
@@ -698,16 +777,23 @@ uint8_t Modbus::createResponse()
  *
  * @return the status code representing the success of this operation
  */
-uint8_t Modbus::executeCallback(uint8_t callbackIndex, uint16_t address, uint16_t length)
+uint8_t Modbus::executeCallback(uint8_t slaveAddress, uint8_t callbackIndex, uint16_t address, uint16_t length)
 {
-    if (cbVector[callbackIndex])
+    for (uint8_t i = 0; i < _numberOfSlaves; ++i)
     {
-        return cbVector[callbackIndex](Modbus::readFunctionCode(), address, length);
+        if (_slaves[i].getUnitAddress() == slaveAddress)
+        {
+            if (_slaves[i].cbVector[callbackIndex])
+            {
+                return _slaves[i].cbVector[callbackIndex](Modbus::readFunctionCode(), address, length);
+            }
+            else
+            {
+                return STATUS_ILLEGAL_FUNCTION;
+            }
+        }
     }
-    else
-    {
-        return STATUS_ILLEGAL_FUNCTION;
-    }
+    return STATUS_ILLEGAL_FUNCTION;
 }
 
 /**

--- a/src/ModbusSlave.cpp
+++ b/src/ModbusSlave.cpp
@@ -682,6 +682,7 @@ uint8_t Modbus::createResponse()
     uint16_t firstAddress;
     uint16_t addressesLength;
     uint8_t callbackIndex;
+    uint16_t requestUnitAddress = _requestBuffer[MODBUS_ADDRESS_INDEX];
 
     /**
      * Match the function code with a callback and execute it
@@ -694,7 +695,7 @@ uint8_t Modbus::createResponse()
         _responseBufferLength += 1;
 
         // execute callback and return the status code
-        return Modbus::executeCallback(_requestBuffer[MODBUS_ADDRESS_INDEX], CB_READ_EXCEPTION_STATUS, 0, 8);
+        return Modbus::executeCallback(requestUnitAddress, CB_READ_EXCEPTION_STATUS, 0, 8);
     case FC_READ_COILS:          // read coils (digital out state)
     case FC_READ_DISCRETE_INPUT: // read input state (digital in)
         // read the the first input address and the number of inputs
@@ -707,7 +708,7 @@ uint8_t Modbus::createResponse()
 
         // execute callback and return the status code
         callbackIndex = _requestBuffer[MODBUS_FUNCTION_CODE_INDEX] == FC_READ_COILS ? CB_READ_COILS : CB_READ_DISCRETE_INPUTS;
-        return Modbus::executeCallback(_requestBuffer[MODBUS_ADDRESS_INDEX], callbackIndex, firstAddress, addressesLength);
+        return Modbus::executeCallback(requestUnitAddress, callbackIndex, firstAddress, addressesLength);
     case FC_READ_HOLDING_REGISTERS: // read holding registers (analog out state)
     case FC_READ_INPUT_REGISTERS:   // read input registers (analog in)
         // read the starting address and the number of inputs
@@ -720,7 +721,7 @@ uint8_t Modbus::createResponse()
 
         // execute callback and return the status code
         callbackIndex = _requestBuffer[MODBUS_FUNCTION_CODE_INDEX] == FC_READ_HOLDING_REGISTERS ? CB_READ_HOLDING_REGISTERS : CB_READ_INPUT_REGISTERS;
-        return Modbus::executeCallback(_requestBuffer[MODBUS_ADDRESS_INDEX], callbackIndex, firstAddress, addressesLength);
+        return Modbus::executeCallback(requestUnitAddress, callbackIndex, firstAddress, addressesLength);
     case FC_WRITE_COIL: // write one coil (digital out)
         // read the address
         firstAddress = readUInt16(_requestBuffer, MODBUS_DATA_INDEX);
@@ -731,7 +732,7 @@ uint8_t Modbus::createResponse()
         memcpy(_responseBuffer + MODBUS_DATA_INDEX, _requestBuffer + MODBUS_DATA_INDEX, _responseBufferLength - MODBUS_FRAME_SIZE);
 
         // execute callback and return the status code
-        return Modbus::executeCallback(_requestBuffer[MODBUS_ADDRESS_INDEX], CB_WRITE_COILS, firstAddress, 1);
+        return Modbus::executeCallback(requestUnitAddress, CB_WRITE_COILS, firstAddress, 1);
     case FC_WRITE_REGISTER:
         // read the address
         firstAddress = readUInt16(_requestBuffer, MODBUS_DATA_INDEX);
@@ -742,7 +743,7 @@ uint8_t Modbus::createResponse()
         memcpy(_responseBuffer + MODBUS_DATA_INDEX, _requestBuffer + MODBUS_DATA_INDEX, _responseBufferLength - MODBUS_FRAME_SIZE);
 
         // execute callback and return the status code
-        return Modbus::executeCallback(_requestBuffer[MODBUS_ADDRESS_INDEX], CB_WRITE_HOLDING_REGISTERS, firstAddress, 1);
+        return Modbus::executeCallback(requestUnitAddress, CB_WRITE_HOLDING_REGISTERS, firstAddress, 1);
     case FC_WRITE_MULTIPLE_COILS: // write coils (digital out)
         // read the starting address and the number of outputs
         firstAddress = readUInt16(_requestBuffer, MODBUS_DATA_INDEX);
@@ -754,7 +755,7 @@ uint8_t Modbus::createResponse()
         memcpy(_responseBuffer + MODBUS_DATA_INDEX, _requestBuffer + MODBUS_DATA_INDEX, _responseBufferLength - MODBUS_FRAME_SIZE);
         
         // execute callback and return the status code
-        return Modbus::executeCallback(_requestBuffer[MODBUS_ADDRESS_INDEX], CB_WRITE_COILS, firstAddress, addressesLength);
+        return Modbus::executeCallback(requestUnitAddress, CB_WRITE_COILS, firstAddress, addressesLength);
     case FC_WRITE_MULTIPLE_REGISTERS: // write holding registers (analog out)
         // read the starting address and the number of outputs
         firstAddress = readUInt16(_requestBuffer, MODBUS_DATA_INDEX);
@@ -766,7 +767,7 @@ uint8_t Modbus::createResponse()
         memcpy(_responseBuffer + MODBUS_DATA_INDEX, _requestBuffer + MODBUS_DATA_INDEX, _responseBufferLength - MODBUS_FRAME_SIZE);
 
         // execute callback and return the status code
-        return Modbus::executeCallback(_requestBuffer[MODBUS_ADDRESS_INDEX], CB_WRITE_HOLDING_REGISTERS, firstAddress, addressesLength);
+        return Modbus::executeCallback(requestUnitAddress, CB_WRITE_HOLDING_REGISTERS, firstAddress, addressesLength);
     default:
         return STATUS_ILLEGAL_FUNCTION;
     }

--- a/src/ModbusSlave.h
+++ b/src/ModbusSlave.h
@@ -115,6 +115,13 @@ public:
     uint64_t getTotalBytesSent();
     uint64_t getTotalBytesReceived();
 
+    // This cbVector is a pointer to cbVector of the first slave, to allow shorthand syntax:
+    //     Modbus slave(SLAVE_ID, CTRL_PIN);
+    //     slave.cbVector[CB_WRITE_COILS] = writeDigitalOut;
+    // Instead of the compleate:
+    //     ModbusSlave slaves[1] = { ModbusSlave(ID_SLAVE_1) };
+    //     Modbus modbus(slaves, 1);
+    //     slaves[0].cbVector[CB_WRITE_COILS] = writeDigitalOut;
     ModbusCallback* cbVector;
 private:
     ModbusSlave* _slaves = new ModbusSlave();

--- a/src/ModbusSlave.h
+++ b/src/ModbusSlave.h
@@ -71,7 +71,20 @@ enum {
   STATUS_GATEWAY_TARGET_DEVICE_FAILED_TO_RESPOND,
 };
 
-typedef uint8_t (*MobbusCallback)(uint8_t, uint16_t, uint16_t);
+typedef uint8_t (*ModbusCallback)(uint8_t, uint16_t, uint16_t);
+
+/**
+ * @class ModbusSlave
+ */
+class ModbusSlave {
+public:
+    ModbusSlave(uint8_t unitAddress = MODBUS_DEFAULT_UNIT_ADDRESS);
+    uint8_t getUnitAddress();
+    void setUnitAddress(uint8_t unitAddress);
+    ModbusCallback cbVector[CB_MAX];
+private:
+    uint8_t _unitAddress = MODBUS_DEFAULT_UNIT_ADDRESS;
+};
 
 /**
  * @class Modbus
@@ -79,7 +92,9 @@ typedef uint8_t (*MobbusCallback)(uint8_t, uint16_t, uint16_t);
 class Modbus {
 public:
     Modbus(uint8_t unitAddress = MODBUS_DEFAULT_UNIT_ADDRESS, int transmissionControlPin = MODBUS_CONTROL_PIN_NONE);
+    Modbus(ModbusSlave* slaves, uint8_t numberOfSlaves, int transmissionControlPin = MODBUS_CONTROL_PIN_NONE);
     Modbus(Stream &serialStream, uint8_t unitAddress = MODBUS_DEFAULT_UNIT_ADDRESS, int transmissionControlPin = MODBUS_CONTROL_PIN_NONE);
+    Modbus(Stream &serialStream, ModbusSlave* slaves, uint8_t numberOfSlaves, int transmissionControlPin = MODBUS_CONTROL_PIN_NONE);
 
     void begin(uint64_t boudRate);
     void setUnitAddress(uint8_t unitAddress);
@@ -100,12 +115,14 @@ public:
     uint64_t getTotalBytesSent();
     uint64_t getTotalBytesReceived();
 
-    MobbusCallback cbVector[CB_MAX];
+    ModbusCallback* cbVector;
 private:
+    ModbusSlave* _slaves = new ModbusSlave();
+    uint8_t _numberOfSlaves = 1;
+
     Stream &_serialStream;
     int _serialTransmissionBufferLength = SERIAL_TX_BUFFER_SIZE;
     int _transmissionControlPin = MODBUS_CONTROL_PIN_NONE;
-    uint8_t _unitAddress = MODBUS_DEFAULT_UNIT_ADDRESS;
 
     uint16_t _halfCharTimeInMicroSecond;
     uint64_t _lastCommunicationTime;
@@ -122,10 +139,11 @@ private:
     uint64_t _totalBytesSent = 0;
     uint64_t _totalBytesReceived = 0;
     
+    bool relevantAddress(uint8_t unitAddress);
     bool readRequest();
     bool validateRequest();
     uint8_t createResponse();
-    uint8_t executeCallback(uint8_t callbackIndex, uint16_t address, uint16_t length);
+    uint8_t executeCallback(uint8_t slaveAddress, uint8_t callbackIndex, uint16_t address, uint16_t length);
     uint16_t writeResponse();
     uint16_t reportException(uint8_t exceptionCode);
     uint16_t calculateCRC(uint8_t *buffer, int length);


### PR DESCRIPTION
This patch allows the configuration of multiple slaves on one device.

My personal use case is similar to a gateway as I have to connect multiple non Modbus devices to a RS485 Modbus setup. I neither want to create a additional Addressing in the payload nor do I want to use multiple Arduinos.

The API of the current master was left untouched and will work as before.

Here is an example on how to test this:
```C
#include <ModbusSlave.h>

#define NUMBER_OF_SLAVES  2
#define ID_SLAVE_1        1
#define ID_SLAVE_2        3

// Initialize the array of slaves
ModbusSlave slaves[NUMBER_OF_SLAVES] = { ModbusSlave(ID_SLAVE_1), ModbusSlave(ID_SLAVE_2) };

// Create the Modbus Object with the the slave array 
Modbus modbus(slaves, NUMBER_OF_SLAVES);

void setup() {
    // register handler functions for the slaves
    slaves[0].cbVector[CB_READ_INPUT_REGISTERS] = ReadAnalogInSlave1;
    slaves[1].cbVector[CB_READ_INPUT_REGISTERS] = ReadAnalogInSlave2;
    
    // start slave at baud 9600 on Serial
    Serial.begin( 9600 ); // baud = 9600
    modbus.begin( 9600 );
}

void loop() {
    // listen for modbus commands con serial port
    modbus.poll();
}

// Handel Read Input Registers (FC=04)
uint8_t ReadAnalogInSlave1(uint8_t fc, uint16_t address, uint16_t length) {
    // write registers into the answer buffer
    for (int i = 0; i < length; i++) {
      modbus.writeRegisterToBuffer(i, i+1);
    }
    return STATUS_OK;
}

// Handel Read Input Registers (FC=04)
uint8_t ReadAnalogInSlave2(uint8_t fc, uint16_t address, uint16_t length) {
    // write registers into the answer buffer
    for (int i = 0; i < length; i++) {
      modbus.writeRegisterToBuffer(i, length-i);
    }
    return STATUS_OK;
} 
```