### PR TITLE
fix broadcast on merge #62

### DIFF
--- a/src/ModbusSlave.cpp
+++ b/src/ModbusSlave.cpp
@@ -589,7 +589,7 @@ bool Modbus::readRequest()
 bool Modbus::relevantAddress(uint8_t unitAddress)
 {
     // Every device should listen to broadcast messages.
-    if (isBroadcast())
+    if (unitAddress==MODBUS_BROADCAST_ADDRESS)
     {
         return true;
     }
@@ -838,7 +838,7 @@ uint8_t Modbus::executeCallback(uint8_t slaveAddress, uint8_t callbackIndex, uin
         }
     }
 
-    return isBroadcast ? STATUS_ACKNOWLEDGE : STATUS_ILLEGAL_FUNCTION;
+    return isBroadcast ? STATUS_OK : STATUS_ILLEGAL_FUNCTION;
 }
 
 /**


### PR DESCRIPTION
#62 still did not fully work => the callback was not called

fixed with 
```diff
@@ -589,7 +590,7 @@ bool Modbus::readRequest()
 bool Modbus::relevantAddress(uint8_t unitAddress)
 {
     // Every device should listen to broadcast messages.
-    if (isBroadcast())
+    if (unitAddress==MODBUS_BROADCAST_ADDRESS)
     {
         return true;
     }
```

secondly:

```
@@ -838,7 +839,7 @@ uint8_t Modbus::executeCallback(uint8_t slaveAddress, uint8_t callbackIndex, uin
         }
     }
 
-    return isBroadcast ? STATUS_ACKNOWLEDGE : STATUS_ILLEGAL_FUNCTION;
+    return isBroadcast ? STATUS_OK : STATUS_ILLEGAL_FUNCTION;
 }
 
 /**
```

for cleanup later and prevent acknowledge