### PR TITLE
fix #61: Don't respond to bogus frames 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@
 .clang_complete
 .gcc-flags.json
 /.vscode/*
+**/.vscode/*


### PR DESCRIPTION
as per @IanAber (#61) prevent sending STATUS_ILLEGAL_FUNCTION on a bogus frame:
- `validateRequest()`: move CRC and validate address to start of procedure

Some extras for extra snappy performance optimalisations:
- `relevantAddress()`: keep the check it local in , since we provide the `unitAddress` to check for broadcast.
- `validateRequest()`: keep is_Broadcast check local , it's all here i.s.o. calling isBroadcast() => `calling readUnitAddress()` : inline with `createResponse()`
- `executeCallback`: remove bool `isbroadcast` and avoid thus extra branch check and memory usage