### PR TITLE
Issue #74 Enable / disable communication

### DIFF
--- a/src/ModbusSlave.cpp
+++ b/src/ModbusSlave.cpp
@@ -152,6 +152,32 @@ void Modbus::setUnitAddress(uint8_t unitAddress)
 }
 
 /**
+ * Enables communication.
+ */
+void Modbus::enable()
+{
+    _enabled = true;
+} 
+
+/**
+ * Disable communication.
+ */
+void Modbus::disable()
+{
+    _enabled = false;
+}
+
+/**
+ * Gets the enable status.
+ * 
+ * @return The enable state.
+ */
+bool Modbus::readEnabled()
+{
+    return _enabled;
+}
+
+/**
  * Gets the total number of bytes sent.
  *
  * @return The number of bytes.
@@ -232,6 +258,12 @@ uint8_t Modbus::poll()
     _responseBuffer[MODBUS_ADDRESS_INDEX] = _requestBuffer[MODBUS_ADDRESS_INDEX];
     _responseBuffer[MODBUS_FUNCTION_CODE_INDEX] = _requestBuffer[MODBUS_FUNCTION_CODE_INDEX];
     _responseBufferLength = MODBUS_FRAME_SIZE;
+
+    // If communication is not enabled, skip processing
+    if (!_enabled)
+    {
+        return 0;
+    }
 
     // Validate the incoming request.
     if (!Modbus::validateRequest())

--- a/src/ModbusSlave.h
+++ b/src/ModbusSlave.h
@@ -104,6 +104,8 @@ public:
 
   void begin(uint64_t boudRate);
   void setUnitAddress(uint8_t unitAddress);
+  void enable();
+  void disable();
   uint8_t poll();
 
   bool readCoilFromBuffer(int offset);
@@ -116,6 +118,7 @@ public:
 
   uint8_t readFunctionCode();
   uint8_t readUnitAddress();
+  bool readEnabled();
   bool isBroadcast();
 
   uint64_t getTotalBytesSent();
@@ -133,6 +136,8 @@ public:
 private:
   ModbusSlave *_slaves = new ModbusSlave();
   uint8_t _numberOfSlaves = 1;
+
+  bool _enabled = true;
 
   Stream &_serialStream;
 


### PR DESCRIPTION
Created a new private variable: bool _enabled and two methods to change (enable() and disable()), as well as one to check the status (readEnabled()).

poll() checks the status of _enable, just before validating the request.  If enable is not true, the function returns without processing the request.

Tested as working.