### PR TITLE
Fix ESP32/ESP8266 Serial Buffer Size

### DIFF
--- a/src/ModbusSlave.h
+++ b/src/ModbusSlave.h
@@ -25,7 +25,7 @@
 #define MODBUS_CONTROL_PIN_NONE -1
 
 #if defined (ESP32) || defined (ESP8266)
-  #define SERIAL_BUFFER_SIZE 128
+  #define SERIAL_BUFFER_SIZE 256
 #endif
 
 /**


### PR DESCRIPTION
Fix ESP32/ESP8266 Buffer Size to 256 Bytes, which is default in the Arduino Core.