### PR TITLE
Added posibility for applying "context" of modbus callback

### DIFF
--- a/src/ModbusSlave.cpp
+++ b/src/ModbusSlave.cpp
@@ -867,14 +867,14 @@ uint8_t Modbus::executeCallback(uint8_t slaveAddress, uint8_t callbackIndex, uin
         {
             if (callback)
             {
-                callback(Modbus::readFunctionCode(), address, length);
+                callback(Modbus::readFunctionCode(), address, length,_pModbusCallbackContext);
             }
         }
         else if (_slaves[i].getUnitAddress() == slaveAddress)
         {
             if (callback)
             {
-                return callback(Modbus::readFunctionCode(), address, length);
+                return callback(Modbus::readFunctionCode(), address, length,_pModbusCallbackContext);
             }
             else
             {
@@ -1027,6 +1027,14 @@ uint16_t Modbus::reportException(uint8_t exceptionCode)
 
     return Modbus::writeResponse();
 }
+
+
+
+void Modbus::setCallbackContext(void* pModbusCallbackContext) noexcept
+{
+    _pModbusCallbackContext = pModbusCallbackContext;
+}
+
 
 /**
  * Calculate the CRC of the passed byte array from zero up to the passed length.

--- a/src/ModbusSlave.h
+++ b/src/ModbusSlave.h
@@ -119,7 +119,7 @@ enum
   STATUS_GATEWAY_TARGET_DEVICE_FAILED_TO_RESPOND,
 };
 
-typedef uint8_t (*ModbusCallback)(uint8_t, uint16_t, uint16_t);
+using ModbusCallback = uint8_t (*)(uint8_t, uint16_t, uint16_t, void*);
 
 /**
  * @class ModbusSlave
@@ -169,6 +169,8 @@ public:
   uint64_t getTotalBytesSent();
   uint64_t getTotalBytesReceived();
 
+  void setCallbackContext(void* pModbusCallbackContext) noexcept;
+
   // This cbVector is a pointer to cbVector of the first slave, to allow shorthand syntax:
   //     Modbus slave(SLAVE_ID, CTRL_PIN);
   //     slave.cbVector[CB_WRITE_COILS] = writeDigitalOut;
@@ -208,6 +210,8 @@ private:
 
   uint64_t _totalBytesSent = 0;
   uint64_t _totalBytesReceived = 0;
+
+  void* _pModbusCallbackContext = nullptr;
 
   bool relevantAddress(uint8_t unitAddress);
   bool readRequest();


### PR DESCRIPTION
I've decided to use the library for adding Modbus support for fun-project and faced with the issue that it's impossible to set up callback for read/write as a class member. For fixing this I've added the possibility to apply "context" for callback context, which can be later user for forwaring handling procedure into the corresponding instance.

1. Setup callbackContext:
```cpp
m_slave.setCallbackContext(this);
```

2. Add callbacks to the multiplexer:
```cpp
etl::flat_map<u16, ModbusRegisterHandler, modbus::address::kModbusRegistersCount> m_modbusRequestsMultiplexer;

        m_modbusRequestsMultiplexer[modbus::address::kTargetTemperatureAddr] =
            ModbusRegisterHandler{
                .readHandler = etl::delegate<u16()>::create<ModbusServer::ModbusServerImpl, &ModbusServerImpl::getTargetTemperature>(*this),
                .writeHandler = etl::delegate<void(u16)>::create<ModbusServer::ModbusServerImpl, &ModbusServerImpl::setTargetTemperature>(*this)};

```
4. Implement basic callbacks:
```cpp

u8 writeDigitalOutCb(u8 fc, u16 address, u16 length, void *callbackContext) noexcept
{
    const bool isAddrValid = (address == modbus::LED_COIL_ADDR);
    if (!isAddrValid)
    {
        return STATUS_ILLEGAL_DATA_ADDRESS;
    }

    auto modbusServerImpl = reinterpret_cast<ModbusServer::ModbusServerImpl *>(callbackContext);
    modbusServerImpl->handleCoilsWrite();
    return STATUS_OK;
}

u8 readHoldingRegistersCb(u8 fc, u16 address, u16 length, void *callbackContext) noexcept
{
    auto modbusServerImpl = reinterpret_cast<ModbusServer::ModbusServerImpl *>(callbackContext);
    return modbusServerImpl->handleReadHoldingRequest(address, length);
}

u8 writeHoldingRegistersCb(u8 fc, u16 address, u16 length, void *callbackContext) noexcept
{
    auto modbusServerImpl = reinterpret_cast<ModbusServer::ModbusServerImpl *>(callbackContext);
    return modbusServerImpl->handleWriteHoldingRegisterRequest(address, length);

}
``` 
The full code is available here:
https://github.com/ValentiWorkLearning/ReflowTableModbusController/blob/master/src/modbus_server_task.cpp