### PR TITLE
Arduino Due support

### DIFF
--- a/src/ModbusSlave.cpp
+++ b/src/ModbusSlave.cpp
@@ -98,8 +98,13 @@ Modbus::Modbus(uint8_t unitAddress, int transmissionControlPin)
  * @param unitAddress The modbus slave unit address.
  * @param transmissionControlPin The digital out pin to be used for RS485 transmission control.
  */
+#if defined(ARDUINO_SAM_DUE)
 Modbus::Modbus(UARTClass &serialStream, uint8_t unitAddress, int transmissionControlPin)
     : _serialStream(serialStream)
+#else
+Modbus::Modbus(Stream &serialStream, uint8_t unitAddress, int transmissionControlPin)
+    : _serialStream(serialStream)
+#endif
 {
     // Set modbus slave unit id.
     _slaves[0].setUnitAddress(unitAddress);
@@ -129,8 +134,13 @@ Modbus::Modbus(ModbusSlave *slaves, uint8_t numberOfSlaves, int transmissionCont
  * @param numberOfSlaves The number of ModbusSlaves in the array.
  * @param transmissionControlPin The digital out pin to be used for RS485 transmission control.
  */
+#if defined(ARDUINO_SAM_DUE)
 Modbus::Modbus(UARTClass &serialStream, ModbusSlave *slaves, uint8_t numberOfSlaves, int transmissionControlPin)
     : _serialStream(serialStream)
+#else
+Modbus::Modbus(Stream &serialStream, ModbusSlave *slaves, uint8_t numberOfSlaves, int transmissionControlPin)
+    : _serialStream(serialStream)
+#endif
 {
     // Set the modbus slaves.
     _slaves = slaves;

--- a/src/ModbusSlave.cpp
+++ b/src/ModbusSlave.cpp
@@ -98,7 +98,7 @@ Modbus::Modbus(uint8_t unitAddress, int transmissionControlPin)
  * @param unitAddress The modbus slave unit address.
  * @param transmissionControlPin The digital out pin to be used for RS485 transmission control.
  */
-Modbus::Modbus(Stream &serialStream, uint8_t unitAddress, int transmissionControlPin)
+Modbus::Modbus(UARTClass &serialStream, uint8_t unitAddress, int transmissionControlPin)
     : _serialStream(serialStream)
 {
     // Set modbus slave unit id.
@@ -129,7 +129,7 @@ Modbus::Modbus(ModbusSlave *slaves, uint8_t numberOfSlaves, int transmissionCont
  * @param numberOfSlaves The number of ModbusSlaves in the array.
  * @param transmissionControlPin The digital out pin to be used for RS485 transmission control.
  */
-Modbus::Modbus(Stream &serialStream, ModbusSlave *slaves, uint8_t numberOfSlaves, int transmissionControlPin)
+Modbus::Modbus(UARTClass &serialStream, ModbusSlave *slaves, uint8_t numberOfSlaves, int transmissionControlPin)
     : _serialStream(serialStream)
 {
     // Set the modbus slaves.

--- a/src/ModbusSlave.h
+++ b/src/ModbusSlave.h
@@ -144,8 +144,13 @@ class Modbus
 public:
   Modbus(uint8_t unitAddress = MODBUS_DEFAULT_UNIT_ADDRESS, int transmissionControlPin = MODBUS_CONTROL_PIN_NONE);
   Modbus(ModbusSlave *slaves, uint8_t numberOfSlaves, int transmissionControlPin = MODBUS_CONTROL_PIN_NONE);
+#if defined(ARDUINO_SAM_DUE)
   Modbus(UARTClass &serialStream, uint8_t unitAddress = MODBUS_DEFAULT_UNIT_ADDRESS, int transmissionControlPin = MODBUS_CONTROL_PIN_NONE);
   Modbus(UARTClass &serialStream, ModbusSlave *slaves, uint8_t numberOfSlaves, int transmissionControlPin = MODBUS_CONTROL_PIN_NONE);
+#else
+  Modbus(Stream &serialStream, uint8_t unitAddress = MODBUS_DEFAULT_UNIT_ADDRESS, int transmissionControlPin = MODBUS_CONTROL_PIN_NONE);
+  Modbus(Stream &serialStream, ModbusSlave *slaves, uint8_t numberOfSlaves, int transmissionControlPin = MODBUS_CONTROL_PIN_NONE);
+#endif
 
   void begin(uint64_t boudRate);
   void setUnitAddress(uint8_t unitAddress);
@@ -186,7 +191,11 @@ private:
 
   bool _enabled = true;
 
+#if defined(ARDUINO_SAM_DUE)
   UARTClass &_serialStream;
+#else
+  Stream &_serialStream;
+#endif
 
 #if defined(SERIAL_TX_BUFFER_SIZE) && !defined (ESP32) && !defined (ESP8266)
   int _serialTransmissionBufferLength = SERIAL_TX_BUFFER_SIZE;

--- a/src/ModbusSlave.h
+++ b/src/ModbusSlave.h
@@ -144,8 +144,8 @@ class Modbus
 public:
   Modbus(uint8_t unitAddress = MODBUS_DEFAULT_UNIT_ADDRESS, int transmissionControlPin = MODBUS_CONTROL_PIN_NONE);
   Modbus(ModbusSlave *slaves, uint8_t numberOfSlaves, int transmissionControlPin = MODBUS_CONTROL_PIN_NONE);
-  Modbus(Stream &serialStream, uint8_t unitAddress = MODBUS_DEFAULT_UNIT_ADDRESS, int transmissionControlPin = MODBUS_CONTROL_PIN_NONE);
-  Modbus(Stream &serialStream, ModbusSlave *slaves, uint8_t numberOfSlaves, int transmissionControlPin = MODBUS_CONTROL_PIN_NONE);
+  Modbus(UARTClass &serialStream, uint8_t unitAddress = MODBUS_DEFAULT_UNIT_ADDRESS, int transmissionControlPin = MODBUS_CONTROL_PIN_NONE);
+  Modbus(UARTClass &serialStream, ModbusSlave *slaves, uint8_t numberOfSlaves, int transmissionControlPin = MODBUS_CONTROL_PIN_NONE);
 
   void begin(uint64_t boudRate);
   void setUnitAddress(uint8_t unitAddress);
@@ -186,7 +186,7 @@ private:
 
   bool _enabled = true;
 
-  Stream &_serialStream;
+  UARTClass &_serialStream;
 
 #if defined(SERIAL_TX_BUFFER_SIZE) && !defined (ESP32) && !defined (ESP8266)
   int _serialTransmissionBufferLength = SERIAL_TX_BUFFER_SIZE;


### PR DESCRIPTION
I have added support for the Arduino Due board.

This library currently doesn't work with Arduino Due, as during compilation there will be error that the function `availableForWrite()` is not defined in class `Stream`. That is true, because on Due that function is instead defined in the `UARTClass` class, which is derived from Stream.

The solution here is just to replace every `Stream` reference to a `UARTClass` reference. I have also added guards so that this substitution only happens when compiling specifically for the DUE board. That way this pull request will have no effect when compiling this library for any other board.

Please note that I don't have much experience with C++, so I am not sure if the way I have implemented guards is the correct or most efficient way of going about this. But this method does work and it compiles properly for the Due board.